### PR TITLE
feat: make working status be visible even when user scrolls

### DIFF
--- a/source/php/Module/views/partials/working.blade.php
+++ b/source/php/Module/views/partials/working.blade.php
@@ -7,94 +7,98 @@
         'data-js-frontend-form-working' => 'true'
     ]
 ])
-
-    @icon([
-        'icon' => 'send',
-        'size' => 'xxl',
-        'classList' => [
-            'mod-frontend-form__working-icon'
-        ],
-        'attributeList' => [
-            'data-js-frontend-form-working__icon' => 'true'
-        ]
-    ])
-    @endicon
-
-    @progressBar([
-        'classList' => [
-            'mod-frontend-form__working-progress-bar'
-        ],
-        'attributeList' => [
-            'data-js-frontend-form-working__progress' => 'true'
-        ],
-        'value' => 25,
-    ])
-    @endprogressBar
-
     @element(['classList' => [
-        'u-display--flex',
-        'u-flex--column',
-        'u-align-items--center',
-        'u-justify-content--center',
-        'u-flex-direction--column',
-        'u-gap--1']
-    ])
-        @typography([
-            'element' => 'div',
-            'variant' => 'body',
-            'classList' => [
-                'mod-frontend-form__working-title'
-            ],
-            'attributeList' => [
-                'data-js-frontend-form-working__title' => 'true'
-            ],
-        ])
-            {{ $lang->submitting ?? 'Submitting'}}
-        @endtypography
-        
-        @typography([
-            'element' => 'div',
-            'variant' => 'meta',
-            'classList' => [
-                'mod-frontend-form__working-description'
-            ],
-            'attributeList' => [
-                'data-js-frontend-form-working__description' => 'true'
-            ],
-        ])
-            {{ $lang->submitInit ?? 'Preparing' }}
-        @endtypography
-    @endelement
-    @element([
-        'classList' => [
-            'mod-frontend-form__working-button'
+        'mod-frontend-form__working-content'
         ]
     ])
-        @button([
-            'style' => 'outlined',
-            'color' => 'secondary',
-            'size' => 'md',
+        @icon([
+            'icon' => 'send',
+            'size' => 'xxl',
             'classList' => [
-                'u-display--none'
+                'mod-frontend-form__working-icon'
             ],
             'attributeList' => [
-                'data-js-frontend-form-working-return-button' => 'true'
-            ],
-            'text' => $lang->return ?? 'Return'
+                'data-js-frontend-form-working__icon' => 'true'
+            ]
         ])
-        @endbutton
-        @button([
-            'style' => 'filled',
-            'color' => 'secondary',
-            'size' => 'md',
+        @endicon
+
+        @progressBar([
             'classList' => [
-                'u-display--none'
+                'mod-frontend-form__working-progress-bar'
             ],
             'attributeList' => [
-                'data-js-frontend-form-working-try-again-button' => 'true'
+                'data-js-frontend-form-working__progress' => 'true'
             ],
-            'text' => $lang->tryAgain ?? 'Try again'
+            'value' => 25,
         ])
-        @endbutton
+        @endprogressBar
+
+        @element(['classList' => [
+            'u-display--flex',
+            'u-flex--column',
+            'u-align-items--center',
+            'u-justify-content--center',
+            'u-flex-direction--column',
+            'u-gap--1']
+        ])
+            @typography([
+                'element' => 'div',
+                'variant' => 'body',
+                'classList' => [
+                    'mod-frontend-form__working-title'
+                ],
+                'attributeList' => [
+                    'data-js-frontend-form-working__title' => 'true'
+                ],
+            ])
+                {{ $lang->submitting ?? 'Submitting'}}
+            @endtypography
+            
+            @typography([
+                'element' => 'div',
+                'variant' => 'meta',
+                'classList' => [
+                    'mod-frontend-form__working-description'
+                ],
+                'attributeList' => [
+                    'data-js-frontend-form-working__description' => 'true'
+                ],
+            ])
+                {{ $lang->submitInit ?? 'Preparing' }}
+            @endtypography
+        @endelement
+        @element([
+            'classList' => [
+                'mod-frontend-form__working-button'
+            ]
+        ])
+            @button([
+                'style' => 'outlined',
+                'color' => 'secondary',
+                'size' => 'md',
+                'classList' => [
+                    'u-display--none'
+                ],
+                'attributeList' => [
+                    'data-js-frontend-form-working-return-button' => 'true'
+                ],
+                'text' => $lang->return ?? 'Return'
+            ])
+            @endbutton
+            @button([
+                'style' => 'filled',
+                'color' => 'secondary',
+                'size' => 'md',
+                'classList' => [
+                    'u-display--none'
+                ],
+                'attributeList' => [
+                    'data-js-frontend-form-working-try-again-button' => 'true'
+                ],
+                'text' => $lang->tryAgain ?? 'Try again'
+            ])
+            @endbutton
+        @endelement
     @endelement
 @endelement

--- a/source/sass/working.scss
+++ b/source/sass/working.scss
@@ -16,8 +16,17 @@
     padding: calc(var(--base, 8px) * 4);
     z-index: 6000;
 
-    > * {
-        max-width: 400px;
+    > .mod-frontend-form__working-content {
+        width: 90%;
+        max-width: calc(var(--base, 8px) * 50);
+        position: sticky;
+        top: 50%;
+        transform: translateY(-50%);
+        text-align: center;
+        gap: inherit;
+        display: inherit;
+        flex-direction: inherit;
+        align-items: inherit;
     }
 }
 
@@ -30,3 +39,4 @@
 .is-error .mod-frontend-form__working {
     color: #721c24;
 }
+


### PR DESCRIPTION
This pull request updates the frontend "working" state UI by introducing a new wrapper element and corresponding CSS adjustments. The main goal is to improve the layout, positioning, and styling of the loading indicator and its content.

**Frontend structure and style improvements:**

* Added a new `@element` wrapper with the class `mod-frontend-form__working-content` in `working.blade.php` to encapsulate the content within the working state component. [[1]](diffhunk://#diff-2ff7bb8175dcaabe6718b71fc18bcc07a35d8c96961ff4a3b793389e962a3b78L10-R13) [[2]](diffhunk://#diff-2ff7bb8175dcaabe6718b71fc18bcc07a35d8c96961ff4a3b793389e962a3b78R104)
* Updated `.mod-frontend-form__working-content` styles in `working.scss` to set width, max-width, sticky positioning, vertical centering, and improved text alignment and layout inheritance.

**Minor style update:**

* Added a newline at the end of `working.scss` for consistency.